### PR TITLE
feat: bump web-lib for more control over RPC

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,16 +11,39 @@ module.exports = ({
 		]
 	},
 	env: {
+		/* 🔵 - Yearn Finance **************************************************
+		** Stuff used for the SEO or some related elements, like the title, the
+		** github url etc.
+		** - WEBSITE_URI is used to display the og image and get the base URI
+		** - WEBSITE_NAME is used as name displayed on the top of the tab in
+		**   the browser.
+		** - WEBSITE_TITLE should be the name of your website. It may be used
+		**   by third parties to display your app name (coinbase for instance)
+		** - WEBSITE_DESCRIPTION is used in the meta tags
+		** - PROJECT_GITHUB_URL should be the link to your project on GitHub
+		**********************************************************************/
 		WEBSITE_URI: 'https://buyback.yearn.finance/',
 		WEBSITE_NAME: 'YFI Buyback',
 		WEBSITE_TITLE: 'YFI Buyback',
 		WEBSITE_DESCRIPTION: 'You dump, we buy. Simple.',
 		PROJECT_GITHUB_URL: 'https://github.com/yearn/yBuyback',
+
+		/* 🔵 - Yearn Finance **************************************************
+		** Some config used to control the behaviour of the web library. By
+		** default, all of theses are set to false.
+		** USE_WALLET: should we allow the user to connect a wallet via
+		**             metamask or wallet connect?
+		** USE_PRICES: should we fetch the prices for a list of tokens? If true
+		**             the CG_IDS array should be populated with the tokens
+		**             to fetch.
+		** USE_PRICE_TRI_CRYPTO: should we fetch the special Tri Crypto token
+		** 			   price? (require blockchain call)
+		** USE_NETWORKS: indicate if the app should be able to change networks
+		**********************************************************************/
 		USE_WALLET: true,
 		USE_PRICES: true,
 		USE_NETWORKS: false,
 		USE_PRICE_TRI_CRYPTO: false,
-		ALCHEMY_KEY: process.env.ALCHEMY_KEY,
 		CG_IDS: ['yearn-finance'],
 		TOKENS: [
 			['0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e', 18, 1],
@@ -28,11 +51,26 @@ module.exports = ({
 			['0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e', 18, 1337],
 			['0x6b175474e89094c44da98b954eedeac495271d0f', 18, 1337]
 		],
-		RPC_URL: {
-			1: process.env.RPC_URL_MAINNET,
-			250: process.env.RPC_URL_FANTOM || 'https://rpc.ftm.tools',
-			42161: process.env.RPC_URL_ARBITRUM || 'https://arbitrum.public-rpc.com'
+
+		/* 🔵 - Yearn Finance **************************************************
+		** Config over the RPC
+		**********************************************************************/
+		WEB_SOCKET_URL: {
+			1: process.env.WS_URL_MAINNET,
+			250: process.env.WS_URL_FANTOM,
+			42161: process.env.WS_URL_ARBITRUM
 		},
+		JSON_RPC_URL: {
+			1: process.env.RPC_URL_MAINNET,
+			250: process.env.RPC_URL_FANTOM,
+			42161: process.env.RPC_URL_ARBITRUM
+		},
+		ALCHEMY_KEY: process.env.ALCHEMY_KEY,
+		INFURA_KEY: process.env.INFURA_KEY,
+
+		/* 🔵 - Yearn Finance **************************************************
+		** Buyback specific env variables
+		**********************************************************************/
 		BUYBACK_SOURCE: 'https://raw.githubusercontent.com/yearn/ychad-audit/master/reports/financial/buybacks/buybacks.json',
 		BUYBACK_ADDR: '0x6903223578806940bd3ff0c51f87aa43968424c8',
 		LLAMA_STREAM_ADDR: '0x60c7B0c5B3a4Dc8C690b074727a17fF7aA287Ff2',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@web3-react/network-connector": "^6.2.9",
     "@web3-react/types": "^6.0.7",
     "@web3-react/walletconnect-connector": "^6.2.13",
-    "@yearn-finance/web-lib": "^0.8.7",
+    "@yearn-finance/web-lib": "^0.9.3",
     "autoprefixer": "^10.4.7",
     "axios": "^0.27.2",
     "chart.js": "^3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,10 +1739,10 @@
     "@web3-react/types" "^8.0.10-beta.0"
     eventemitter3 "^4.0.7"
 
-"@yearn-finance/web-lib@^0.8.7":
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/@yearn-finance/web-lib/-/web-lib-0.8.7.tgz#b18972910e370dc0b85a4eeae835909d2000614e"
-  integrity sha512-rdygQBSce7e8net0s7BtpHMGe+1Ibx3uErBR9zkk8TTcCBHxhQD2LvaK/i8uJV9c0p3RVWNrX6xF/nFoTrYvkA==
+"@yearn-finance/web-lib@^0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@yearn-finance/web-lib/-/web-lib-0.9.3.tgz#171a9585e51059f5dfe700927c4cc7cce551e930"
+  integrity sha512-h4ZdkL7m58SU4oRgkYJnRoueCO6WnkQPidkUlWdX51e1ghGqyG5kHqaE5xLjBI5GjnbwSC9QHjSQxVn/XSNCHw==
   dependencies:
     "@coinbase/wallet-sdk" "^3.1.0"
     "@ethersproject/experimental" "^5.6.2"
@@ -1766,6 +1766,7 @@
     eventemitter3 "^4.0.7"
     framer-motion "^6.3.4"
     nprogress "^0.2.0"
+    postcss "^8.4.14"
     react-flip-move "^3.0.4"
     react-hot-toast "^2.2.0"
     react-virtualized "^9.22.3"


### PR DESCRIPTION
Upgrade the web-lib to V0.9.x, which enable more RPC settings.

For the supported networks, the logic is now this one:
```
is a webSocketURL env set ?
	then use it
is a jsonRPCURL env set ?
	then use it
is an Alchemy key set ?
	then use it
if an Infura set ?
	then use it
Otherwise, use the default RPC
```

Default RPC are [https://rpc.flashbots.net](https://rpc.flashbots.net) for Ethereum Mainnet and [https://rpc.ftm.tools](https://rpc.ftm.tools) for Fantom Network. Exact implementation is available in the web-lib [here](https://github.com/yearn/web-lib/blob/main/packages/web-lib/utils/providers.tsx#L31-L92).

In order to customise the env variable, you can create a `.env` file with the following informations:
```
WS_URL_MAINNET=wss://xxxxxxx
WS_URL_FANTOM=wss://xxxxxxx
WS_URL_ARBITRUM=wss://xxxxxxx
RPC_URL_MAINNET=https://xxxxxxx
RPC_URL_FANTOM=https://xxxxxxx
RPC_URL_ARBITRUM=https://xxxxxxx
ALCHEMY_KEY=xxxxxxx
INFURA_KEY=xxxxxxx
```